### PR TITLE
Secure database credentials and create analytics schema

### DIFF
--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -24,12 +24,13 @@ from ..schemas.analytics import (
 
 logger = logging.getLogger(__name__)
 
-# GCP PostgreSQL Database Configuration
-GCP_DB_HOST = "34.140.49.230"
-GCP_DB_PORT = 5432
-GCP_DB_NAME = "vtsi"
-GCP_DB_USER = "jason"
-GCP_DB_PASSWORD = "*9ZS^l(HGq].BA]6"
+# GCP PostgreSQL Database Configuration (from environment/secrets)
+import os
+GCP_DB_HOST = os.getenv("VTTI_DB_HOST", "34.140.49.230")
+GCP_DB_PORT = int(os.getenv("VTTI_DB_PORT", "5432"))
+GCP_DB_NAME = os.getenv("VTTI_DB_NAME", "vtsi")
+GCP_DB_USER = os.getenv("VTTI_DB_USER")
+GCP_DB_PASSWORD = os.getenv("VTTI_DB_PASSWORD")
 
 
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -41,8 +41,8 @@ steps:
       - '--max-instances=10'
       - '--min-instances=0'
       - '--add-cloudsql-instances=symbolic-cinema-305010:europe-west1:vtsi-postgres'
-      - '--set-env-vars=VTTI_DB_INSTANCE_CONNECTION_NAME=symbolic-cinema-305010:europe-west1:vtsi-postgres,VTTI_DB_NAME=vtsi,MCDM_BIN_MINUTES=15,MCDM_LOOKBACK_HOURS=24'
-      - '--set-secrets=VTTI_DB_USER=db_user:1,VTTI_DB_PASSWORD=db_password:1'
+      - '--set-env-vars=VTTI_DB_INSTANCE_CONNECTION_NAME=symbolic-cinema-305010:europe-west1:vtsi-postgres,VTTI_DB_NAME=vtsi,VTTI_DB_HOST=34.140.49.230,VTTI_DB_PORT=5432,MCDM_BIN_MINUTES=15,MCDM_LOOKBACK_HOURS=24'
+      - '--set-secrets=VTTI_DB_USER=db_user:latest,VTTI_DB_PASSWORD=db_password:latest'
       - '--quiet'
     id: 'Deploy'
 

--- a/backend/db/migrations/002_create_analytics_schema.sql
+++ b/backend/db/migrations/002_create_analytics_schema.sql
@@ -1,0 +1,56 @@
+-- Migration: Create separate schema for analytics features
+-- This keeps crash validation data separate from real-time safety indices
+
+-- Create analytics schema
+CREATE SCHEMA IF NOT EXISTS analytics;
+
+-- Grant permissions
+GRANT USAGE ON SCHEMA analytics TO jason;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO jason;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA analytics TO jason;
+
+-- Set default privileges for future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT ALL PRIVILEGES ON TABLES TO jason;
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT ALL PRIVILEGES ON SEQUENCES TO jason;
+
+-- Create table for crash correlation cache (optional - for performance)
+CREATE TABLE IF NOT EXISTS analytics.crash_correlation_cache (
+    id SERIAL PRIMARY KEY,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    threshold FLOAT NOT NULL,
+    proximity_radius FLOAT NOT NULL,
+    total_crashes INT NOT NULL,
+    total_intervals INT NOT NULL,
+    crash_rate FLOAT NOT NULL,
+    true_positives INT NOT NULL,
+    false_positives INT NOT NULL,
+    true_negatives INT NOT NULL,
+    false_negatives INT NOT NULL,
+    precision FLOAT NOT NULL,
+    recall FLOAT NOT NULL,
+    f1_score FLOAT NOT NULL,
+    accuracy FLOAT NOT NULL,
+    pearson_correlation FLOAT NOT NULL,
+    spearman_correlation FLOAT NOT NULL,
+    computed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(start_date, end_date, threshold, proximity_radius)
+);
+
+CREATE INDEX idx_crash_cache_dates ON analytics.crash_correlation_cache(start_date, end_date);
+
+-- Create view for monitored intersections (if needed)
+CREATE OR REPLACE VIEW analytics.monitored_intersections AS
+SELECT
+    id as intersection_id,
+    name,
+    latitude,
+    longitude,
+    created_at,
+    updated_at
+FROM public.intersections
+ORDER BY id;
+
+COMMENT ON SCHEMA analytics IS 'Analytics and validation features for crash correlation analysis';
+COMMENT ON TABLE analytics.crash_correlation_cache IS 'Cached correlation metrics to improve query performance';
+COMMENT ON VIEW analytics.monitored_intersections IS 'View of intersections being monitored for safety indices';

--- a/backend/db/migrations/README.md
+++ b/backend/db/migrations/README.md
@@ -1,0 +1,42 @@
+# Database Migrations
+
+This directory contains SQL migration scripts for the GCP PostgreSQL database.
+
+## Running Migrations
+
+Connect to the GCP database and run migrations in order:
+
+```bash
+# Connect to database
+psql -h 34.140.49.230 -p 5432 -U jason -d vtsi
+
+# Run migrations
+\i backend/db/migrations/002_create_analytics_schema.sql
+```
+
+## Migration History
+
+| # | File | Description | Date |
+|---|------|-------------|------|
+| 001 | 01_init_schema.sql | Initial schema for safety indices | 2025-11-21 |
+| 002 | 002_create_analytics_schema.sql | Analytics schema for crash validation | 2025-12-01 |
+
+## Schema Organization
+
+**public schema:**
+- `intersections` - Monitored intersection locations
+- `safety_indices_realtime` - Real-time safety index data
+- `vcc_*` tables - VCC message data (BSM, PSM, MapData)
+
+**analytics schema:**
+- `crash_correlation_cache` - Cached correlation metrics
+- `monitored_intersections` (view) - View into public.intersections
+
+**External (GCP vtsi database):**
+- `vdot_crashes` - Virginia crash data (accessed via analytics_service.py)
+
+## Notes
+
+- The analytics schema is separate to avoid mixing validation data with production safety indices
+- The `vdot_crashes` table exists in the same GCP database but is managed separately
+- Cache tables are optional performance optimizations


### PR DESCRIPTION
Security improvements:
- Remove hardcoded database credentials from analytics_service.py
- Use environment variables from secrets for GCP database access
- Update Cloud Build to use latest secret versions
- Add VTTI_DB_HOST and VTTI_DB_PORT env vars

Database organization:
- Create separate 'analytics' schema for crash validation features
- Keep production safety indices in 'public' schema
- Add crash_correlation_cache table for performance
- Create monitored_intersections view

Secret Manager updates:
- Created db_password secret with production credentials
- Updated db_user to version 3 (username: jason)
- Granted Cloud Run service account access to secrets
- Changed from pinned versions (:1) to :latest for flexibility

Migration files:
- backend/db/migrations/002_create_analytics_schema.sql
- backend/db/migrations/README.md

This ensures credentials are never committed to git and analytics features have a dedicated schema separate from production data.

🤖 Generated with Claude Code (https://claude.com/claude-code)