### PR TITLE
perf(safety-index): TTL cache + dedup for /safety/index endpoint

### DIFF
--- a/backend/app/api/intersection.py
+++ b/backend/app/api/intersection.py
@@ -15,6 +15,7 @@ from ..services.db_client import get_db_client
 from ..services.mcdm_service import MCDMSafetyIndexService
 from ..services.rt_si_service import RTSIService
 from ..core.config import settings
+from ..core.cache import TTLCache
 from ..core.intersection_mapping import (
     normalize_intersection_name,
     validate_intersection_in_tables,
@@ -23,6 +24,13 @@ from ..core.intersection_mapping import (
 
 router = APIRouter(prefix="/safety/index", tags=["Safety Index"])
 logger = logging.getLogger(__name__)
+
+# The safety-index listing recomputes RT-SI/MCDM for every intersection on each
+# request; the underlying data only refreshes on the 15-minute bin boundary, so
+# a short-lived response cache makes all but the first request near-instant.
+# 5-minute TTL bounds staleness well under one data-refresh cycle.
+_SAFETY_INDEX_CACHE_TTL = 300
+_safety_index_cache = TTLCache(ttl_seconds=_SAFETY_INDEX_CACHE_TTL)
 
 
 def find_crash_intersection_for_bsm(bsm_intersection: str, db_client) -> list:
@@ -165,6 +173,13 @@ def list_intersections(
     - GET /api/v1/safety/index/?alpha=0.0 - Pure MCDM
     """
 
+    # Serve from cache when a recent identical request is still fresh.
+    cache_key = ("list_intersections", round(alpha, 4), include_mcdm, bin_minutes)
+    hit, cached = _safety_index_cache.get(cache_key)
+    if hit:
+        logger.info(f"safety-index cache hit for {cache_key}")
+        return cached
+
     db_client = get_db_client()
     rt_si_service = RTSIService(db_client)
     mcdm_service = MCDMSafetyIndexService(db_client)
@@ -172,13 +187,16 @@ def list_intersections(
     # Get available BSM intersections
     bsm_intersections = mcdm_service.get_available_intersections()
 
-    # Build mapping_results for all intersections
+    # Build crash-intersection mappings once. mapping_results keeps the first
+    # entry (for get_all); full_mappings keeps the whole list so the
+    # per-intersection loop below can reuse it instead of re-querying.
     mapping_results = {}
+    full_mappings: dict[str, list] = {}
     for intersection in bsm_intersections:
         mapping_list = find_crash_intersection_for_bsm(intersection, db_client)
         if mapping_list:
-            # Use the first valid mapping for each intersection
             mapping_results[intersection] = mapping_list[0]
+            full_mappings[intersection] = mapping_list
 
     # Get base intersection data (coordinates, traffic volume, etc.)
     base_intersections = get_all(mapping_results)
@@ -225,10 +243,9 @@ def list_intersections(
         # Calculate RT-SI (primary safety index)
         rt_si_calculated = False
         if bsm_intersection_name:
-            # Use find_crash_intersection_for_bsm to get the proper crash intersection ID
-            crash_intersection_list = find_crash_intersection_for_bsm(
-                bsm_intersection_name, db_client
-            )
+            # Reuse the crash mapping computed once above (avoids a second
+            # find_crash_intersection_for_bsm round-trip per intersection).
+            crash_intersection_list = full_mappings.get(bsm_intersection_name, [])
             # Use first valid result with crash_intersection_id
             valid_crash = next(
                 (
@@ -319,6 +336,9 @@ def list_intersections(
         logger.info(
             f"Returning {len(results)} intersections with RT-SI as primary index"
         )
+        # Only cache non-empty results — an empty list usually means a
+        # transient upstream failure we shouldn't pin for the TTL window.
+        _safety_index_cache.set(cache_key, results)
 
     return results
 

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,0 +1,58 @@
+"""
+TTLCache
+========
+A minimal, thread-safe time-to-live cache for expensive endpoint responses.
+
+The safety-index endpoints recompute 18 intersections from scratch on every
+request, even though the underlying data is only refreshed every 15 minutes.
+Caching a whole response for a few minutes turns a multi-minute endpoint into
+a sub-second one for all but the first request.
+
+The clock is injectable so TTL expiry can be tested deterministically.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Hashable
+
+
+class TTLCache:
+    """A small key/value cache where entries expire after ``ttl_seconds``."""
+
+    def __init__(
+        self,
+        ttl_seconds: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._clock = clock
+        self._store: dict[Hashable, tuple[float, Any]] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: Hashable) -> tuple[bool, Any]:
+        """
+        Return ``(hit, value)``. ``hit`` is False on a miss or an expired
+        entry; expired entries are evicted on access.
+        """
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return False, None
+            stored_at, value = entry
+            if self._clock() - stored_at > self._ttl:
+                del self._store[key]
+                return False, None
+            return True, value
+
+    def set(self, key: Hashable, value: Any) -> None:
+        """Store ``value`` under ``key`` with a fresh timestamp."""
+        with self._lock:
+            self._store[key] = (self._clock(), value)
+
+    def clear(self) -> None:
+        """Drop every cached entry."""
+        with self._lock:
+            self._store.clear()

--- a/tests/backend/test_cache.py
+++ b/tests/backend/test_cache.py
@@ -1,0 +1,86 @@
+"""
+Backend tests - TTLCache
+========================
+Tests for the time-to-live response cache used to make the expensive
+/api/v1/safety/index/ endpoint cheap on repeat calls.
+"""
+
+
+class FakeClock:
+    """A controllable monotonic clock for deterministic TTL tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class TestTTLCache:
+    def test_get_returns_miss_for_unknown_key(self):
+        from app.core.cache import TTLCache
+
+        cache = TTLCache(ttl_seconds=60)
+        hit, value = cache.get("nope")
+        assert hit is False
+        assert value is None
+
+    def test_get_returns_stored_value_within_ttl(self):
+        from app.core.cache import TTLCache
+
+        clock = FakeClock()
+        cache = TTLCache(ttl_seconds=60, clock=clock)
+        cache.set("k", {"score": 42})
+
+        clock.advance(59)  # still inside the TTL window
+        hit, value = cache.get("k")
+        assert hit is True
+        assert value == {"score": 42}
+
+    def test_get_returns_miss_after_ttl_expiry(self):
+        from app.core.cache import TTLCache
+
+        clock = FakeClock()
+        cache = TTLCache(ttl_seconds=60, clock=clock)
+        cache.set("k", "v")
+
+        clock.advance(61)  # past the TTL window
+        hit, value = cache.get("k")
+        assert hit is False
+        assert value is None
+
+    def test_set_overwrites_existing_key(self):
+        from app.core.cache import TTLCache
+
+        clock = FakeClock()
+        cache = TTLCache(ttl_seconds=60, clock=clock)
+        cache.set("k", "first")
+        cache.set("k", "second")
+
+        hit, value = cache.get("k")
+        assert hit is True
+        assert value == "second"
+
+    def test_clear_drops_all_entries(self):
+        from app.core.cache import TTLCache
+
+        cache = TTLCache(ttl_seconds=60)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.clear()
+
+        assert cache.get("a") == (False, None)
+        assert cache.get("b") == (False, None)
+
+    def test_distinct_keys_are_independent(self):
+        from app.core.cache import TTLCache
+
+        cache = TTLCache(ttl_seconds=60)
+        cache.set(("alpha", 0.7), "blended")
+        cache.set(("alpha", 1.0), "pure-rtsi")
+
+        assert cache.get(("alpha", 0.7)) == (True, "blended")
+        assert cache.get(("alpha", 1.0)) == (True, "pure-rtsi")

--- a/tests/demo/validate_groundedness.py
+++ b/tests/demo/validate_groundedness.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import re
 import sys
+import threading
 import time
 
 try:
@@ -109,6 +110,33 @@ VALIDATIONS: list[dict] = [
 # ── HTTP helpers ──────────────────────────────────────────────────────────
 
 
+def _call_with_deadline(fn, deadline_s: float):
+    """
+    Run ``fn()`` under a hard wall-clock deadline. ``requests``' own ``timeout``
+    is per-socket-operation, not total — a server holding the connection open
+    can wedge a call far past it. The worker is a daemon thread, so a hung
+    call leaks one thread but never blocks script exit.
+
+    Raises TimeoutError if ``fn`` does not return within ``deadline_s``.
+    """
+    box: dict = {}
+
+    def runner() -> None:
+        try:
+            box["value"] = fn()
+        except Exception as exc:  # noqa: BLE001 - re-raised on the caller thread
+            box["error"] = exc
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    t.join(deadline_s)
+    if t.is_alive():
+        raise TimeoutError(f"call exceeded {deadline_s:.0f}s hard deadline")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
 def fetch_gt(base: str, gt_file: str | None = None) -> list[dict]:
     """
     Normalised ground-truth rows. Loads from a local JSON file if ``gt_file`` is
@@ -119,7 +147,9 @@ def fetch_gt(base: str, gt_file: str | None = None) -> list[dict]:
         with open(gt_file, encoding="utf-8") as fh:
             payload = json.load(fh)
     else:
-        r = requests.get(f"{base}/api/v1/safety/index/", timeout=120)
+        r = _call_with_deadline(
+            lambda: requests.get(f"{base}/api/v1/safety/index/", timeout=120), 150
+        )
         r.raise_for_status()
         payload = r.json()
     rows = payload if isinstance(payload, list) else payload.get("intersections", [])
@@ -140,12 +170,15 @@ def fetch_gt(base: str, gt_file: str | None = None) -> list[dict]:
 def ask(base: str, q: str) -> tuple[str, float, int | None, str]:
     started = time.perf_counter()
     try:
-        r = requests.post(
-            f"{base}/api/v1/chat/",
-            json={"messages": [{"role": "user", "content": q}]},
-            timeout=300,
+        r = _call_with_deadline(
+            lambda: requests.post(
+                f"{base}/api/v1/chat/",
+                json={"messages": [{"role": "user", "content": q}]},
+                timeout=300,
+            ),
+            330,
         )
-    except requests.RequestException as exc:
+    except (requests.RequestException, TimeoutError) as exc:
         return "", time.perf_counter() - started, None, str(exc)
     latency = time.perf_counter() - started
     if not r.ok:

--- a/tests/demo/verify_demo.py
+++ b/tests/demo/verify_demo.py
@@ -32,6 +32,7 @@ import argparse
 import json
 import re
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 
@@ -161,15 +162,47 @@ class UCResult:
 # ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 
+def _call_with_deadline(fn, deadline_s: float):
+    """
+    Run ``fn()`` under a hard wall-clock deadline.
+
+    ``requests``' own ``timeout`` is per-socket-operation, not total: a server
+    that holds the connection open or trickles bytes can wedge a call far past
+    the nominal timeout (observed: a 300s-timeout POST that ran 47 minutes).
+    The worker is a daemon thread, so a genuinely hung call leaks one thread
+    but never blocks script exit.
+
+    Raises TimeoutError if ``fn`` does not return within ``deadline_s``.
+    """
+    box: dict = {}
+
+    def runner() -> None:
+        try:
+            box["value"] = fn()
+        except Exception as exc:  # noqa: BLE001 - re-raised on the caller thread
+            box["error"] = exc
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    t.join(deadline_s)
+    if t.is_alive():
+        raise TimeoutError(f"call exceeded {deadline_s:.0f}s hard deadline")
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
 def check_health(base: str) -> bool:
     """Confirm the deployment is up before running use cases."""
     for path in ("/health", "/docs"):
         try:
-            r = requests.get(base + path, timeout=30)
+            r = _call_with_deadline(
+                lambda: requests.get(base + path, timeout=30), 45
+            )
             if r.ok:
                 print(f"  health: {base}{path} -> {r.status_code}")
                 return True
-        except requests.RequestException as exc:
+        except (requests.RequestException, TimeoutError) as exc:
             print(f"  health: {base}{path} -> {exc}")
     return False
 
@@ -177,11 +210,13 @@ def check_health(base: str) -> bool:
 def get_tools(base: str) -> list[str]:
     """Fetch the LLM tool definitions; the paper says there are six."""
     try:
-        r = requests.get(f"{base}/api/v1/chat/tools", timeout=30)
+        r = _call_with_deadline(
+            lambda: requests.get(f"{base}/api/v1/chat/tools", timeout=30), 45
+        )
         r.raise_for_status()
         tools = r.json().get("tools", [])
         return [t.get("function", {}).get("name", "?") for t in tools]
-    except requests.RequestException as exc:
+    except (requests.RequestException, TimeoutError) as exc:
         print(f"  WARN: could not fetch /api/v1/chat/tools: {exc}")
         return []
 
@@ -199,10 +234,12 @@ def get_ground_truth(base: str) -> list[dict]:
     volume. An empty list just disables the numeric cross-check (UCs still run).
     """
     try:
-        r = requests.get(f"{base}/api/v1/safety/index/", timeout=120)
+        r = _call_with_deadline(
+            lambda: requests.get(f"{base}/api/v1/safety/index/", timeout=120), 150
+        )
         r.raise_for_status()
         payload = r.json()
-    except (requests.RequestException, ValueError) as exc:
+    except (requests.RequestException, ValueError, TimeoutError) as exc:
         print(f"  WARN: could not fetch ground truth /safety/index/: {exc}")
         return []
 
@@ -256,9 +293,11 @@ def ask(base: str, query: str) -> tuple[int | None, float, str, str]:
     body = {"messages": [{"role": "user", "content": query}]}
     started = time.perf_counter()
     try:
-        r = requests.post(url, json=body, timeout=300)
+        r = _call_with_deadline(
+            lambda: requests.post(url, json=body, timeout=300), 330
+        )
         latency = time.perf_counter() - started
-    except requests.RequestException as exc:
+    except (requests.RequestException, TimeoutError) as exc:
         return None, time.perf_counter() - started, "", str(exc)
 
     if not r.ok:


### PR DESCRIPTION
## Why

`/api/v1/safety/index/` recomputes RT-SI + MCDM for all 18 intersections on **every** request. Measured in production: **>4.5 min** (curl timed out at 280s). The Streamlit dashboard's primary data source is effectively unusable, and it wedged `verify_demo.py` / `validate_groundedness.py`.

Root-cause investigation (4 compounding causes) is in the thread; this PR lands the two contained, low-risk ones.

## What

In `list_intersections` (`backend/app/api/intersection.py`):

1. **TTL response cache** — new `app/core/cache.py::TTLCache`, 5-min TTL keyed by `(alpha, include_mcdm, bin_minutes)`. The data only refreshes on the 15-min bin boundary, so 5-min staleness is well within one cycle. Every repeat request becomes near-instant. Empty results aren't cached (transient upstream failures shouldn't be pinned).
2. **Dedup `find_crash_intersection_for_bsm`** — it ran once in the mapping loop *and* again per-intersection (36 calls for 18 sites). The per-intersection loop now reuses the mapping built once.

## Not in this PR

- **Parallelize the loop** — blocked: `db_client` uses `psycopg2.SimpleConnectionPool`, which is **not thread-safe** (the likely source of the `connection already closed` errors). Needs a `ThreadedConnectionPool` migration first — separate PR.
- **Precompute table** — under investigation (existing `safety_indices_*` tables may make this a read-only change).
- **Cold-call latency** — the cache fixes *repeat* calls; the first request after a Cloud Run cold start still recomputes. That needs parallelize/precompute.

## Tests

- `TTLCache` TDD'd with an injectable clock — 6 tests (`tests/backend/test_cache.py`).
- Backend suite **30/30** pass. My additions are ruff-clean (4 pre-existing warnings in `intersection.py` untouched).

## Verification plan

Local docker integration test is blocked (this machine's IP isn't on the Cloud SQL authorized-networks list; production is unaffected). Plan: merge → Cloud Build redeploy → `curl` production `/safety/index/` twice and confirm cold-vs-warm (first slow, second sub-second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)