### PR TITLE
refactor(chat): morning-briefing fast path → fallback only

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -791,15 +791,23 @@ def _risk_label(score: float) -> str:
     return "low risk"
 
 
-def _dominant_criteria(row: dict) -> str:
-    candidates = [
-        ("vehicle volume", row.get("vehicle_count"), "{:,.0f} vehicles"),
-        ("VRU activity", row.get("vru_count"), "{:,.0f} VRUs"),
-        ("incident activity", row.get("incident_count"), "{:,.0f} incidents"),
-        ("speed variance", row.get("speed_variance"), "{:.2f}"),
+def _real_time_readings(row: dict) -> str:
+    """
+    Comma-joined list of a row's raw real-time figures, in a fixed order.
+
+    These are *reported counts*, not a causal attribution: the fast path does
+    not have the CRITIC-weighted per-criterion contributions needed to say
+    which criterion drove the MCDM score, so it must not claim one did.
+    Returns "" when no figure is present.
+    """
+    fields = [
+        (row.get("vehicle_count"), "{:,.0f} vehicles"),
+        (row.get("vru_count"), "{:,.0f} VRUs"),
+        (row.get("incident_count"), "{:,.0f} incidents"),
+        (row.get("speed_variance"), "speed variance {:.2f}"),
     ]
-    present = []
-    for label, value, fmt in candidates:
+    parts = []
+    for value, fmt in fields:
         if value is None:
             continue
         try:
@@ -807,13 +815,8 @@ def _dominant_criteria(row: dict) -> str:
         except (TypeError, ValueError):
             continue
         if numeric > 0:
-            present.append((label, numeric, fmt.format(numeric)))
-    if not present:
-        return "no elevated real-time criteria"
-    # Use raw magnitudes only to choose a concise explanation; the MCDM score
-    # itself remains the ranked safety signal.
-    present.sort(key=lambda item: item[1], reverse=True)
-    return ", ".join(f"{label} ({formatted})" for label, _, formatted in present[:3])
+            parts.append(fmt.format(numeric))
+    return ", ".join(parts)
 
 
 def _run_morning_briefing_fast_path() -> str:
@@ -840,14 +843,20 @@ def _run_morning_briefing_fast_path() -> str:
         f"{f' ({data_time})' if data_time else ''}: "
     )
 
+    rank_words = {1: "ranks highest", 2: "ranks second", 3: "ranks third"}
     sentences = []
     for idx, row in enumerate(top_rows, start=1):
         score = float(row.get("mcdm", 0.0) or 0.0)
-        sentences.append(
-            f"{idx}. {_display_intersection(row.get('intersection', 'unknown'))} "
-            f"ranks highest with an MCDM score of {score:.2f} "
-            f"({_risk_label(score)}), driven by {_dominant_criteria(row)}."
+        rank_word = rank_words.get(idx, f"ranks #{idx}")
+        name = _display_intersection(row.get("intersection", "unknown"))
+        sentence = (
+            f"{idx}. {name} {rank_word} with an MCDM score of {score:.2f} "
+            f"({_risk_label(score)})"
         )
+        readings = _real_time_readings(row)
+        if readings:
+            sentence += f"; current readings: {readings}"
+        sentences.append(sentence + ".")
 
     if len(rankings) > 2:
         remaining_scores = [float(r.get("mcdm", 0.0) or 0.0) for r in rankings[2:]]

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1017,21 +1017,34 @@ def run_chat(messages: list[dict]) -> str:
     Raises
     ------
     ValueError
-        If OPENAI_API_KEY is not configured.
+        If OPENAI_API_KEY is not configured (non-briefing queries only).
     RuntimeError
-        If the OpenAI API call fails.
+        If the openai package is not installed.
+
+    Notes
+    -----
+    The deterministic morning-briefing path is a *fallback*: the agent
+    answers the canonical UC1 query normally, and the template is served
+    only when OpenAI is unavailable (no key, or the API call fails), so the
+    demo still works if OpenAI is down. Non-briefing queries surface any
+    OpenAI failure to the caller unchanged.
     """
-    if _is_morning_briefing_request(messages):
-        return _run_morning_briefing_fast_path()
+    is_briefing = _is_morning_briefing_request(messages)
 
     if not settings.OPENAI_API_KEY:
+        if is_briefing:
+            logger.warning(
+                "OPENAI_API_KEY not set; serving the deterministic "
+                "morning-briefing fallback"
+            )
+            return _run_morning_briefing_fast_path()
         raise ValueError(
             "OPENAI_API_KEY is not set. "
             "Add it to backend/.env: OPENAI_API_KEY=sk-..."
         )
 
     try:
-        from openai import OpenAI
+        from openai import OpenAI, OpenAIError
     except ImportError as exc:
         raise RuntimeError(
             "openai package is not installed. "
@@ -1061,38 +1074,49 @@ def run_chat(messages: list[dict]) -> str:
 
     # Agentic loop: keep calling until no more tool calls
     max_iterations = 6  # prevent runaway loops
-    for _ in range(max_iterations):
-        response = client.chat.completions.create(
-            model=settings.OPENAI_MODEL,
-            messages=full_messages,
-            tools=TOOLS,
-            tool_choice="auto",
-            max_tokens=settings.OPENAI_MAX_TOKENS,
-        )
-
-        choice = response.choices[0]
-        assistant_msg = choice.message
-
-        # Append assistant turn to history
-        full_messages.append(assistant_msg.model_dump(exclude_unset=True))
-
-        if choice.finish_reason != "tool_calls" or not assistant_msg.tool_calls:
-            # Final text response
-            return assistant_msg.content or ""
-
-        # Execute each tool call and feed results back
-        for tool_call in assistant_msg.tool_calls:
-            tool_result = _dispatch_tool_call(
-                tool_call.function.name,
-                tool_call.function.arguments,
+    try:
+        for _ in range(max_iterations):
+            response = client.chat.completions.create(
+                model=settings.OPENAI_MODEL,
+                messages=full_messages,
+                tools=TOOLS,
+                tool_choice="auto",
+                max_tokens=settings.OPENAI_MAX_TOKENS,
             )
-            full_messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tool_call.id,
-                    "content": tool_result,
-                }
+
+            choice = response.choices[0]
+            assistant_msg = choice.message
+
+            # Append assistant turn to history
+            full_messages.append(assistant_msg.model_dump(exclude_unset=True))
+
+            if choice.finish_reason != "tool_calls" or not assistant_msg.tool_calls:
+                # Final text response
+                return assistant_msg.content or ""
+
+            # Execute each tool call and feed results back
+            for tool_call in assistant_msg.tool_calls:
+                tool_result = _dispatch_tool_call(
+                    tool_call.function.name,
+                    tool_call.function.arguments,
+                )
+                full_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": tool_result,
+                    }
+                )
+    except OpenAIError as exc:
+        # OpenAI failed (quota, rate limit, outage). The deterministic
+        # briefing can still answer UC1; any other query must surface it.
+        if is_briefing:
+            logger.warning(
+                f"OpenAI call failed ({type(exc).__name__}); serving the "
+                f"deterministic morning-briefing fallback"
             )
+            return _run_morning_briefing_fast_path()
+        raise
 
     # Safety fallback: return whatever the model has
     last = full_messages[-1]

--- a/tests/backend/test_chat_service.py
+++ b/tests/backend/test_chat_service.py
@@ -204,8 +204,9 @@ class TestCompareIntersections:
 
     def test_morning_briefing_uses_fast_path_without_openai(self):
         """
-        The canonical UC1 query should not enter the OpenAI agent loop; it is a
-        fixed latest-data ranking plus concise operator summary.
+        When OpenAI is unavailable (here: no API key), the canonical UC1 query
+        falls back to the deterministic latest-data ranking plus concise
+        operator summary instead of erroring.
         """
         with patch(
             "app.services.chat_service._execute_compare_intersections",
@@ -422,3 +423,101 @@ class TestGetTrendData:
             _, start_time, end_time = args
             assert end_time == ANCHOR
             assert end_time - start_time == timedelta(days=7)
+
+
+# ---------------------------------------------------------------------------
+# Morning-briefing deterministic fallback
+# ---------------------------------------------------------------------------
+
+class TestMorningBriefingFallback:
+    """
+    The deterministic morning-briefing path is a *fallback* — it runs only
+    when the OpenAI agent is unavailable, never as the default for the
+    canonical UC1 query.
+    """
+
+    def _briefing_messages(self):
+        return [{
+            "role": "user",
+            "content": "Give me a morning safety briefing for all intersections.",
+        }]
+
+    def _llm_response(self, text):
+        """A mock OpenAI response carrying a final (non-tool-call) reply."""
+        msg = MagicMock()
+        msg.content = text
+        msg.tool_calls = None
+        msg.model_dump.return_value = {"role": "assistant", "content": text}
+        choice = MagicMock()
+        choice.finish_reason = "stop"
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+        return resp
+
+    def test_briefing_uses_agent_when_openai_available(self):
+        """With a working key, the briefing goes through the agent loop —
+        not the deterministic template."""
+        with patch("app.services.chat_service.settings") as mock_settings, \
+             patch("openai.OpenAI") as openai_cls:
+            mock_settings.OPENAI_API_KEY = "sk-test"
+            mock_settings.OPENAI_MODEL = "gpt-4o"
+            mock_settings.OPENAI_MAX_TOKENS = 1024
+            client = openai_cls.return_value
+            client.chat.completions.create.return_value = self._llm_response(
+                "Agent-generated briefing."
+            )
+
+            from app.services.chat_service import run_chat
+            reply = run_chat(self._briefing_messages())
+
+            client.chat.completions.create.assert_called()
+            assert reply == "Agent-generated briefing."
+
+    def test_briefing_falls_back_when_openai_errors(self):
+        """If the OpenAI call fails, the briefing degrades to the
+        deterministic fast path instead of erroring."""
+        from openai import OpenAIError
+        with patch("app.services.chat_service.settings") as mock_settings, \
+             patch("openai.OpenAI") as openai_cls, \
+             patch(
+                 "app.services.chat_service._execute_compare_intersections",
+                 return_value={
+                     "rankings": [{
+                         "intersection": "e_broad_st-n_washington_st",
+                         "mcdm": 75.0, "vehicle_count": 200, "vru_count": 20,
+                         "incident_count": 4, "speed_variance": 18.0,
+                     }],
+                     "data_time": "2025-11-01 17:00:00",
+                 },
+             ):
+            mock_settings.OPENAI_API_KEY = "sk-test"
+            mock_settings.OPENAI_MODEL = "gpt-4o"
+            mock_settings.OPENAI_MAX_TOKENS = 1024
+            client = openai_cls.return_value
+            client.chat.completions.create.side_effect = OpenAIError(
+                "insufficient_quota"
+            )
+
+            from app.services.chat_service import run_chat
+            reply = run_chat(self._briefing_messages())
+
+            client.chat.completions.create.assert_called()
+            assert "Morning safety briefing" in reply
+            assert "E Broad St & N Washington St" in reply
+
+    def test_non_briefing_query_does_not_fall_back_on_openai_error(self):
+        """A non-briefing query must surface OpenAI failures — the
+        deterministic path can only answer the briefing."""
+        from openai import OpenAIError
+        with patch("app.services.chat_service.settings") as mock_settings, \
+             patch("openai.OpenAI") as openai_cls:
+            mock_settings.OPENAI_API_KEY = "sk-test"
+            mock_settings.OPENAI_MODEL = "gpt-4o"
+            mock_settings.OPENAI_MAX_TOKENS = 1024
+            client = openai_cls.return_value
+            client.chat.completions.create.side_effect = OpenAIError("boom")
+
+            from app.services.chat_service import run_chat
+            with pytest.raises(OpenAIError):
+                run_chat([{"role": "user", "content": "What is the weather?"}])

--- a/tests/backend/test_chat_service.py
+++ b/tests/backend/test_chat_service.py
@@ -521,3 +521,49 @@ class TestMorningBriefingFallback:
             from app.services.chat_service import run_chat
             with pytest.raises(OpenAIError):
                 run_chat([{"role": "user", "content": "What is the weather?"}])
+
+
+class TestMorningBriefingOutput:
+    """Quality of the deterministic morning-briefing text."""
+
+    def test_ranked_rows_use_distinct_wording(self):
+        """Each ranked row must be described by its own position — only the
+        first is 'highest'."""
+        with patch(
+            "app.services.chat_service._execute_compare_intersections",
+            return_value={
+                "rankings": [
+                    {"intersection": "e_broad_st-n_washington_st", "mcdm": 75.0,
+                     "vehicle_count": 200, "vru_count": 20, "incident_count": 4,
+                     "speed_variance": 18.0},
+                    {"intersection": "birch_st-w_broad_st", "mcdm": 50.0,
+                     "vehicle_count": 100, "vru_count": 10, "incident_count": 2,
+                     "speed_variance": 12.0},
+                ],
+                "data_time": "2025-11-01 17:00:00",
+            },
+        ):
+            from app.services.chat_service import _run_morning_briefing_fast_path
+            reply = _run_morning_briefing_fast_path()
+            assert reply.count("ranks highest") == 1
+            assert "ranks second" in reply
+
+    def test_does_not_claim_false_causation(self):
+        """The fast path lacks CRITIC-weighted contributions, so it must not
+        claim a criterion 'drove' the score — it reports raw figures only."""
+        with patch(
+            "app.services.chat_service._execute_compare_intersections",
+            return_value={
+                "rankings": [
+                    {"intersection": "e_broad_st-n_washington_st", "mcdm": 75.0,
+                     "vehicle_count": 1089, "vru_count": 59, "incident_count": 11,
+                     "speed_variance": 37.0},
+                ],
+                "data_time": "2025-11-01 17:00:00",
+            },
+        ):
+            from app.services.chat_service import _run_morning_briefing_fast_path
+            reply = _run_morning_briefing_fast_path()
+            assert "driven by" not in reply.lower()
+            # raw figures are still surfaced, just not as a causal claim
+            assert "1,089 vehicles" in reply


### PR DESCRIPTION
## Why

The deterministic morning-briefing path (commit `9ab583a`) ran for **every** canonical UC1 query, bypassing the OpenAI agent — contradicting the paper's "agentic / tool-augmented LLM" framing (§4.1 promises attendees see LLM tool-call traces; there were none for UC1). Its template output also had two defects.

## What

**1. Fast path → fallback only.** `run_chat` uses the **agent** for the briefing when OpenAI works; the deterministic template is served **only when OpenAI is unavailable**: no `OPENAI_API_KEY`, or the call raises `OpenAIError` (quota / rate limit / outage). Non-briefing queries surface OpenAI failures unchanged. Net: UC1 is honestly agentic when OpenAI works, and the demo still produces a briefing if OpenAI dies mid-conference.

**2. Honest template wording** (defects fixed):
- Every ranked row said "ranks highest" → row 2 now says "ranks second".
- `"driven by <criteria>"` implied causation, but the path picked criteria by raw magnitude (vehicle counts always win across incomparable units) with no CRITIC-weighted contributions. Replaced with `"current readings: <figures>"` — descriptive, fixed-order, no false causality. `_dominant_criteria` → `_real_time_readings`.

## Tests (TDD)

- `TestMorningBriefingFallback` — agent used when available; `OpenAIError` → fallback; non-briefing errors propagate.
- `TestMorningBriefingOutput` — distinct rank wording; no causal claims.
- **37/37 backend tests pass**, ruff clean.

## Not in this PR

The MCDM **batching** from `9ab583a` is unchanged — clean, correct, stays unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)