### PR TITLE
paper: drop UC1 'under five seconds' claim; Figure 1 shows 6 tools

### DIFF
--- a/files/acmart-primary/vttsi-chat-demo.tex
+++ b/files/acmart-primary/vttsi-chat-demo.tex
@@ -324,10 +324,12 @@ intersections.''}
 SafetyChat chains \texttt{compare\_intersections} and
 \texttt{get\_component\_breakdown} for the two highest-ranked sites,
 delivering a situational-awareness narrative identifying peak-risk windows
-and dominant criteria (e.g., speed variance, VRU counts) in under five
-seconds.
+and dominant criteria (e.g., speed variance, VRU counts).
 Where the Streamlit dashboard requires navigating multiple spatial charts,
 SafetyChat synthesizes multi-intersection data into a single paragraph.
+If the LLM backend is unavailable, this use case degrades gracefully to a
+deterministic briefing computed directly from the latest safety scores, so
+it remains demonstrable even during an API outage.
 
 \subsection{UC2: Causal Safety Explanation for Planners}
 \textit{Query:} \emph{``Why did E.~Broad--N.~Washington score above 70

--- a/files/system-architecture.tex
+++ b/files/system-architecture.tex
@@ -101,7 +101,9 @@
      \texttt{get\_safety\_score}\\
      \texttt{get\_component\_breakdown}\\
      \texttt{get\_historical\_baseline}\\
-     \texttt{compare\_intersections}};
+     \texttt{compare\_intersections}\\
+     \texttt{get\_trend\_data}\\
+     \texttt{run\_sql\_query}};
 
 \node[llm, right=0.4cm of chatsvc] (llm)
     {\textbf{OpenAI}\\GPT-4o\\[3pt]

--- a/tests/demo/validation_results_prod.json
+++ b/tests/demo/validation_results_prod.json
@@ -1,0 +1,243 @@
+{
+  "base": "https://cs6604-trafficsafety-180117512369.europe-west1.run.app",
+  "ground_truth": [
+    {
+      "name": "birch_st-w_broad_st",
+      "blended": 15.546767552864877,
+      "mcdm": 51.82255850954958,
+      "rt_si": 0.0,
+      "type": "Blended"
+    },
+    {
+      "name": "e_annandale_rd-hillwood_ave",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "e_broad_st-little_falls_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "e_broad_st-n_cherry_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "e_broad_st-n_washington_st",
+      "blended": 15.785415867591626,
+      "mcdm": 52.61805289197208,
+      "rt_si": 0.0,
+      "type": "Blended"
+    },
+    {
+      "name": "e_broad_st-s_roosevelt_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "glebe-potomac",
+      "blended": 0.19842011545026625,
+      "mcdm": 0.6614003848342207,
+      "rt_si": 0.0,
+      "type": "Blended"
+    },
+    {
+      "name": "great_falls_st-n_west_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "hillwood-s_washington_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "hillwood_ave-s_roosevelt_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "n_maple_ave-w_broad_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "n_washington_st-park_place",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "n_west_st-park_ave",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "rowell_ct-w_broad_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "s_virginia_ave-w_broad_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "s_west_st-w_broad_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "tinners_hill-s_washington_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    },
+    {
+      "name": "w_annandale_rd-w_broad_st",
+      "blended": 0.0,
+      "mcdm": 0.0,
+      "rt_si": 0.0,
+      "type": "No Data"
+    }
+  ],
+  "results": [
+    {
+      "id": "V1",
+      "question": "What is the current MCDM safety score for Birch & W. Broad?",
+      "expect": "value",
+      "site": "birch_st-w_broad_st",
+      "field": "mcdm",
+      "reply": "The current MCDM safety score for Birch & W. Broad is 44.95, indicating a moderate risk level.",
+      "latency_s": 6.47,
+      "status": 200,
+      "error": "",
+      "verdict": "MISMATCH",
+      "expected": "mcdm=51.82 (birch_st-w_broad_st)",
+      "detail": "closest claim 44.95; ground truth 51.82"
+    },
+    {
+      "id": "V2",
+      "question": "What is the current MCDM safety score for E. Broad & N. Washington?",
+      "expect": "value",
+      "site": "e_broad_st-n_washington_st",
+      "field": "mcdm",
+      "reply": "The current MCDM safety score for the intersection at E. Broad & N. Washington is 61.17, which indicates moderate risk.",
+      "latency_s": 9.83,
+      "status": 200,
+      "error": "",
+      "verdict": "MISMATCH",
+      "expected": "mcdm=52.62 (e_broad_st-n_washington_st)",
+      "detail": "closest claim 61.17; ground truth 52.62"
+    },
+    {
+      "id": "V3",
+      "question": "What is the current MCDM safety score for Glebe & Potomac?",
+      "expect": "value",
+      "site": "glebe-potomac",
+      "field": "mcdm",
+      "reply": "The current MCDM safety score for the intersection of Glebe Road and Potomac Avenue (Glebe & Potomac) is 0.0, which indicates no identified safety risks based on the Multi-Criteria Decision-Making (MCDM) assessment. The data timestamp is 2025-11-25 16:00.",
+      "latency_s": 4.2,
+      "status": 200,
+      "error": "",
+      "verdict": "MATCH",
+      "expected": "mcdm=0.66 (glebe-potomac)",
+      "detail": "closest claim 0.0 within \u00b12.0 of 0.66"
+    },
+    {
+      "id": "V4",
+      "question": "Which intersection currently has the highest MCDM safety score?",
+      "expect": "argmax",
+      "field": "mcdm",
+      "reply": "The intersection with the highest current MCDM safety score is Broad St & Washington St with an MCDM score of 55.42, which falls into the moderate risk category.",
+      "latency_s": 2.46,
+      "status": 200,
+      "error": "",
+      "verdict": "MATCH",
+      "expected": "top mcdm: e_broad_st-n_washington_st (52.62)",
+      "detail": "reply names e_broad_st-n_washington_st with a superlative"
+    },
+    {
+      "id": "V5",
+      "question": "Is Glebe & Potomac currently higher or lower risk than Birch & W. Broad?",
+      "expect": "compare",
+      "site_a": "glebe-potomac",
+      "site_b": "birch_st-w_broad_st",
+      "field": "mcdm",
+      "reply": "Glebe Rd & Potomac Ave has a blended safety score of **1.35** (low risk), while Birch Rd & W. Broad St has a higher blended score of **14.99** (also low risk). Currently, Birch & W. Broad poses a slightly higher safety risk compared to Glebe & Potomac, but both intersections remain in the low-risk category.",
+      "latency_s": 4.61,
+      "status": 200,
+      "error": "",
+      "verdict": "MANUAL",
+      "expected": "glebe-potomac (0.66) lower than birch_st-w_broad_st (51.82) on mcdm",
+      "detail": "names both sites; comparative verdict unclear from text"
+    },
+    {
+      "id": "V6",
+      "question": "Are there any intersections currently scoring above 70 on the MCDM index?",
+      "expect": "threshold_above",
+      "field": "mcdm",
+      "threshold": 70,
+      "reply": "No, there are currently no intersections scoring above 70 on the MCDM safety index. The highest MCDM score recorded is 55.42 at the \"Broad & Washington\" intersection, which is still in the moderate-risk range.",
+      "latency_s": 2.87,
+      "status": 200,
+      "error": "",
+      "verdict": "MATCH",
+      "expected": "0 site(s) with mcdm > 70",
+      "detail": "GT has none above threshold; reply says none"
+    },
+    {
+      "id": "V7",
+      "question": "How many monitored intersections currently have live telemetry data?",
+      "expect": "count_with_data",
+      "reply": "",
+      "latency_s": 7.2,
+      "status": 402,
+      "error": "OpenAI quota exceeded. Add billing at https://platform.openai.com/account/billing",
+      "verdict": "MISMATCH",
+      "expected": "3 intersection(s) with live data (of 18 monitored)",
+      "detail": "GT count 3; reply numbers: []"
+    },
+    {
+      "id": "V8",
+      "question": "What is the current blended safety index for Birch & W. Broad at alpha=0.7?",
+      "expect": "value",
+      "site": "birch_st-w_broad_st",
+      "field": "blended",
+      "reply": "The current blended safety index for the Birch & W. Broad intersection at alpha=0.7 is 14.99, categorized as low risk.",
+      "latency_s": 6.21,
+      "status": 200,
+      "error": "",
+      "verdict": "MATCH",
+      "expected": "blended=15.55 (birch_st-w_broad_st)",
+      "detail": "closest claim 14.99 within \u00b12.0 of 15.55"
+    }
+  ]
+}

--- a/tests/demo/validation_table_prod.md
+++ b/tests/demo/validation_table_prod.md
@@ -1,0 +1,27 @@
+# SafetyChat groundedness validation
+
+Generated against `https://cs6604-trafficsafety-180117512369.europe-west1.run.app`. Ground truth: 3 sites with live telemetry (of 18 monitored).
+
+Each row asks SafetyChat a question whose correct answer can be read 
+directly from `/api/v1/safety/index/`. *Verdict* is automated: 
+**MATCH** = the answer's number / identified site agrees with ground 
+truth within ±2.0 (for 0-100 scores); **MISMATCH** = a 
+concrete disagreement; **MANUAL** = answer requires a human judgment; 
+**FAIL** = no usable answer.
+
+**Summary:** 4 match / 3 mismatch / 1 manual / 0 fail (of 8).
+
+| ID | Question | Ground truth | SafetyChat answer (excerpt) | Latency | Verdict |
+|---|---|---|---|---:|:---:|
+| V1 | What is the current MCDM safety score for Birch & W. Broad? | mcdm=51.82 (birch_st-w_broad_st) | The current MCDM safety score for Birch & W. Broad is 44.95, indicating a moderate risk level. | 6.5s | **MISMATCH** |
+| V2 | What is the current MCDM safety score for E. Broad & N. Washington? | mcdm=52.62 (e_broad_st-n_washington_st) | The current MCDM safety score for the intersection at E. Broad & N. Washington is 61.17, which indicates moderate risk. | 9.8s | **MISMATCH** |
+| V3 | What is the current MCDM safety score for Glebe & Potomac? | mcdm=0.66 (glebe-potomac) | The current MCDM safety score for the intersection of Glebe Road and Potomac Avenue (Glebe & Potomac) is 0.0, which indicates no identified safety risks based on the Multi-Criteria … | 4.2s | **MATCH** |
+| V4 | Which intersection currently has the highest MCDM safety score? | top mcdm: e_broad_st-n_washington_st (52.62) | The intersection with the highest current MCDM safety score is Broad St & Washington St with an MCDM score of 55.42, which falls into the moderate risk category. | 2.5s | **MATCH** |
+| V5 | Is Glebe & Potomac currently higher or lower risk than Birch & W. Broad? | glebe-potomac (0.66) lower than birch_st-w_broad_st (51.82) on mcdm | Glebe Rd & Potomac Ave has a blended safety score of **1.35** (low risk), while Birch Rd & W. Broad St has a higher blended score of **14.99** (also low risk). Currently, Birch & W … | 4.6s | **MANUAL** |
+| V6 | Are there any intersections currently scoring above 70 on the MCDM index? | 0 site(s) with mcdm > 70 | No, there are currently no intersections scoring above 70 on the MCDM safety index. The highest MCDM score recorded is 55.42 at the "Broad & Washington" intersection, which is stil … | 2.9s | **MATCH** |
+| V7 | How many monitored intersections currently have live telemetry data? | 3 intersection(s) with live data (of 18 monitored) | *(HTTP 402: OpenAI quota exceeded. Add billing at https://platform.openai.com/account/billing)* | 7.2s | **MISMATCH** |
+| V8 | What is the current blended safety index for Birch & W. Broad at alpha=0.7? | blended=15.55 (birch_st-w_broad_st) | The current blended safety index for the Birch & W. Broad intersection at alpha=0.7 is 14.99, categorized as low risk. | 6.2s | **MATCH** |
+
+> Score tolerance ±2.0. "MANUAL" verdicts need human 
+> review of the reply against the ground-truth column. Full replies 
+> and ground-truth rows are in `validation_results.json`.


### PR DESCRIPTION
## Why

Two paper-accuracy fixes flagged in the review passes.

## What

- **§4.2** — removed *"in under five seconds"*. UC1 now routes through the agent (PR #23 made the deterministic path a fallback); measured ~25s warm / 32s cold. The use case's value is the multi-intersection **synthesis**, not latency. Added a sentence stating the graceful-degradation fallback.
- **Figure 1** (`system-architecture.tex`) — the Chat Service node listed 4 tools; §3 describes 6. Added `get_trend_data` and `run_sql_query`.

## Validation table — deliberately NOT in the paper

The production groundedness re-run (`tests/demo/validation_table_prod.md`, committed as a record) came back 4 match / 3 mismatch / 1 manual. It is **not** paper-ready:

- V7 is an **OpenAI-quota 402 artifact**, not a result — the table is incomplete.
- V1/V2 "mismatches" are chat-vs-`/safety/index` snapshot divergence — **both are real tool outputs, not hallucination**. The script measures tool-to-tool *consistency*, not groundedness.

A proper paper table needs the methodology reframed to measure claim ↔ tool-call faithfulness — that is an authorship task. Tracked for the authors.

## Scope

Paper / figure source only — no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)