### PR TITLE
fix(db): thread-safe ThreadedConnectionPool

### DIFF
--- a/backend/app/services/db_client.py
+++ b/backend/app/services/db_client.py
@@ -71,10 +71,13 @@ class VTTIPostgresClient:
             )
 
         try:
-            # Create connection pool
+            # ThreadedConnectionPool (not SimpleConnectionPool): FastAPI runs
+            # synchronous endpoints in a worker thread pool, so the connection
+            # pool is accessed concurrently. SimpleConnectionPool is
+            # single-threaded and races getconn/putconn under that load.
             if self.port is None:
                 # Unix socket mode
-                self.connection_pool = psycopg2.pool.SimpleConnectionPool(
+                self.connection_pool = psycopg2.pool.ThreadedConnectionPool(
                     min_connections,
                     max_connections,
                     host=self.host,
@@ -83,7 +86,7 @@ class VTTIPostgresClient:
                     password=self.password,
                 )
             else:
-                self.connection_pool = psycopg2.pool.SimpleConnectionPool(
+                self.connection_pool = psycopg2.pool.ThreadedConnectionPool(
                     min_connections,
                     max_connections,
                     host=self.host,

--- a/tests/backend/test_db_client.py
+++ b/tests/backend/test_db_client.py
@@ -1,0 +1,31 @@
+"""
+Backend tests - VTTIPostgresClient connection pool
+==================================================
+"""
+from unittest.mock import patch
+
+
+class TestConnectionPool:
+    def test_uses_threaded_connection_pool(self):
+        """
+        The DB client must build a psycopg2 *ThreadedConnectionPool*.
+
+        FastAPI runs synchronous endpoints in a worker thread pool, so several
+        requests touch the connection pool concurrently. psycopg2's
+        SimpleConnectionPool is documented as single-threaded; under that
+        concurrency it hands the same connection to two threads and races
+        getconn/putconn — the source of the intermittent
+        'connection already closed' errors. ThreadedConnectionPool guards
+        the same API with a lock.
+        """
+        with patch("app.services.db_client.psycopg2") as mock_pg:
+            from app.services.db_client import VTTIPostgresClient
+            VTTIPostgresClient(
+                host="db.example",
+                database="d",
+                user="u",
+                password="p",
+                port=5432,
+            )
+            mock_pg.pool.ThreadedConnectionPool.assert_called_once()
+            mock_pg.pool.SimpleConnectionPool.assert_not_called()


### PR DESCRIPTION
## Why

`db_client` built its pool with `psycopg2.SimpleConnectionPool`, documented as **single-threaded**. FastAPI serves synchronous endpoints from a worker thread pool, so the pool is accessed concurrently — `SimpleConnectionPool` races `getconn`/`putconn` and can hand one connection to two threads. This is the source of the intermittent **`connection already closed`** errors seen in the `/safety/index` container logs.

## What

Swap to `psycopg2.ThreadedConnectionPool` — identical constructor + `getconn`/`putconn`/`closeall` API, but lock-guarded. Drop-in change at both pool-construction sites (Unix-socket and TCP).

Also **unblocks** future parallelization of the `/safety/index` per-intersection loop, which was unsafe on the non-thread-safe pool (deferred; the response cache already addresses the latency).

## Tests

`tests/backend/test_db_client.py` — asserts the thread-safe pool class is used (TDD: RED→GREEN verified). **38/38 backend tests pass.**

Two pre-existing ruff F401 warnings in `db_client.py` (unused `pool` / `settings` imports) are unrelated and left untouched.

## Scope / risk

One-file change, drop-in API-compatible. Touches the DB layer every backend service uses — but `ThreadedConnectionPool` is psycopg2's standard thread-safe variant; the only behavioral change is correct locking under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)