### PR TITLE
fix(chat): correct get_historical_baseline query columns

### DIFF
--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -580,16 +580,24 @@ def _execute_get_historical_baseline(args: dict) -> dict:
             }
 
         crash_id = valid["crash_intersection_id"]
+        # Column names and KABCO severity buckets match rt_si_service.py /
+        # find_lambda.py, which query this same table: the matched-intersection
+        # FK is matched_intersection_id, severity is crash_severity (codes
+        # K/A/B or the words Fatal/Injury), and PDO is the residual bucket.
         query = """
             SELECT
                 COUNT(*) AS total_crashes,
-                SUM(CASE WHEN severity = 'Fatal' THEN 1 ELSE 0 END) AS fatal,
-                SUM(CASE WHEN severity = 'Injury' THEN 1 ELSE 0 END) AS injury,
-                SUM(CASE WHEN severity = 'PDO' THEN 1 ELSE 0 END) AS pdo,
+                SUM(CASE WHEN crash_severity IN ('K', 'Fatal')
+                         THEN 1 ELSE 0 END) AS fatal,
+                SUM(CASE WHEN crash_severity IN ('A', 'B', 'Injury')
+                         THEN 1 ELSE 0 END) AS injury,
+                SUM(CASE WHEN crash_severity IN ('K', 'Fatal', 'A', 'B', 'Injury')
+                         THEN 0 ELSE 1 END) AS pdo,
                 MIN(crash_date) AS earliest,
                 MAX(crash_date) AS latest
             FROM public.vdot_crashes_with_intersections
-            WHERE crash_intersection_id = %(crash_id)s
+            WHERE matched_intersection_id = %(crash_id)s
+              AND crash_year BETWEEN 2017 AND 2024
         """
         rows = db.execute_query(query, {"crash_id": crash_id})
         crash_row = rows[0] if rows else {}

--- a/tests/backend/test_chat_service.py
+++ b/tests/backend/test_chat_service.py
@@ -370,6 +370,41 @@ class TestGetHistoricalBaseline:
                 f"expected the plural table name, got SQL: {sql!r}"
             )
 
+    def test_query_uses_real_column_names(self):
+        """
+        The crash-history query must use the columns
+        vdot_crashes_with_intersections actually has — crash_severity and
+        matched_intersection_id — verified against rt_si_service.py and
+        find_lambda.py, which query the same table successfully. 'severity'
+        and 'crash_intersection_id' do not exist (psycopg2 UndefinedColumn).
+        The query is also year-scoped to match its total_crashes_2017_2024 key.
+        """
+        db = MagicMock()
+        db.execute_query.return_value = [{
+            "total_crashes": 5, "fatal": 1, "injury": 2, "pdo": 2,
+            "earliest": "2020-01-01", "latest": "2024-12-01",
+        }]
+        with patch("app.services.chat_service.get_db_client", return_value=db), \
+             patch("app.services.chat_service.MCDMSafetyIndexService") as mcdm_cls, \
+             patch("app.services.chat_service.RTSIService") as rtsi_cls, \
+             patch("app.api.intersection.find_crash_intersection_for_bsm",
+                   return_value=[{"crash_intersection_id": 101}]):
+            mcdm_cls.return_value.get_available_intersections.return_value = [
+                "birch_st-w_broad_st"
+            ]
+            rtsi_cls.return_value.get_eb_params.return_value = {"lambda_star": 10000}
+
+            from app.services.chat_service import _execute_get_historical_baseline
+            _execute_get_historical_baseline({"intersection": "birch"})
+
+            sql = db.execute_query.call_args[0][0]
+            assert "crash_severity" in sql, "must use crash_severity, not severity"
+            assert "matched_intersection_id" in sql, \
+                "must filter on matched_intersection_id, not crash_intersection_id"
+            assert "crash_year" in sql, "must scope to 2017-2024 via crash_year"
+            assert "WHERE crash_intersection_id" not in sql, \
+                "the non-existent crash_intersection_id column must be gone"
+
 
 # ---------------------------------------------------------------------------
 # Latest-data anchoring for the remaining tool handlers


### PR DESCRIPTION
## Root cause (from production Cloud Run logs)

`get_historical_baseline` still errored after the table-name fix (#20). The actual exception:

```
psycopg2.errors.UndefinedColumn: column "severity" does not exist
  at chat_service.py:594  _execute_get_historical_baseline
```

The query was written against a wrong schema model for `vdot_crashes_with_intersections`.

## Fix

Verified the real columns against `rt_si_service.py` and `find_lambda.py` — both query the **same table** successfully:

| Broken | Real column |
|---|---|
| `severity` | `crash_severity` (KABCO codes `K`/`A`/`B`, or words `Fatal`/`Injury`) |
| `WHERE crash_intersection_id` | `WHERE matched_intersection_id` |
| *(no year filter)* | `crash_year BETWEEN 2017 AND 2024` — the result is keyed `total_crashes_2017_2024` but counted all years incl. 2025 |

Fatal/Injury/PDO bucketing now matches the working examples (`K`|`Fatal`→fatal, `A`|`B`|`Injury`→injury, residual→PDO).

## Tests

`test_query_uses_real_column_names` pins the corrected column names + year scope (TDD: RED→GREEN). **39/39 backend tests pass.**

## Note

This is the same class of bug as #20 (wrong table name) and the `top_factors` key fix — the chat tool was written against assumed schema that didn't match reality. Worth a pass over the other chat tools' raw SQL against the actual DB schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)