### PR TITLE
Remediate VTTSI final report for arXiv submission

### DIFF
--- a/files/arxiv-remediation-spec.md
+++ b/files/arxiv-remediation-spec.md
@@ -1,0 +1,90 @@
+# Software Specification: VTTSI Final Report — arXiv Remediation
+
+**Target artifact:** `files/conference_101719.tex` (Virginia Tech Transportation Safety Index, IEEEtran conference format, 21 pp.)
+**Goal:** Make the final class report submission-ready for arXiv by removing factual contradictions, course-only artifacts, and cosmetic defects — without altering the underlying methodology or results.
+**Ground-truth source of record:** the deployed backend in this repo (`backend/app/...`). Where the paper and code disagree, the **code wins**.
+
+---
+
+## 0. Resolved Ground Truth (decisions, not open questions)
+
+| Item | Paper says | Deployed code | Decision |
+|------|-----------|---------------|----------|
+| EB shrinkage λ\* | §IV: `10000`; Appendix: `100000` | `rt_si_service.py:41 LAMBDA = 100000.0` | **λ\* = 100,000** (fix §IV) |
+| Pooled mean r₀ | Appendix: `3.365` | `rt_si_service.py:42 R0 = 3.365` | **r₀ = 3.365** (already correct) |
+| α blending | §IV + Validation: α=0.7 blend; Appendix: "no α applied" | `intersection.py:315` blends, default `alpha=0.7`, API + slider configurable | **α-blend IS shipped, default 0.7** (fix Appendix) |
+
+---
+
+## 1. Functional Requirements
+
+### 1.1 Factual Consistency (Must-have)
+- **FR-001:** The methodology EB optimum `\lambda^\star` MUST read `100000` (currently `10000`, line ~422), matching `LAMBDA = 100000.0` in `rt_si_service.py`. Rationale: a 10× factual contradiction with the appendix and the deployed code.
+- **FR-002:** The appendix "Final Blend" subsection MUST state that α-blending **is** applied in the released code with default `α = 0.7`, configurable via the safety-index API and the Streamlit slider, and MUST reference the blended-index equation in §IV. The sentence "No blending parameter α is applied in the released code" MUST be removed. Rationale: the entire Validation section and four "final-blended" figures depend on the blend; the appendix statement contradicts both the methodology and `intersection.py:315`.
+
+### 1.2 Cross-Reference Integrity (Must-have)
+- **FR-003:** Appendix "Other intersections' results" perturbation sentence MUST reference `fig:perturbed-rt-si-comparison-birch` **and** `fig:perturbed-rt-si-comparison-broad` (currently the second ref wrongly points at `fig:all-variable-normalized-broad`).
+- **FR-004:** The deviation-distribution sentence MUST reference `fig:rt-si-changes-distribution-birch` **and** `fig:rt-si-changes-distribution-broad` (currently the same label `...-broad` is referenced twice).
+
+### 1.3 Scope / Artifact Removal (Must-have)
+- **FR-005:** The entire `\section{Team Member Contribution Report}` appendix (and its `\label{appendix:contributions}`, incl. the "Appendix A" narrative) MUST be removed. Rationale: course-grading artifact written in progress-report / future tense ("is investigating", "upcoming tasks", "under active development"); inappropriate for a public preprint and inconsistent with a finished paper.
+
+### 1.4 Claim Accuracy (Must-have)
+- **FR-006:** The Results §IX sentence claiming perturbation experiments at "(±25% and ±50%)" MUST be reduced to "±25%", since only the ±25% / 50-run experiment is described and plotted (Sensitivity §VIII). Rationale: no ±50% results exist in the paper.
+
+### 1.5 Cosmetic / Hygiene (Should-have)
+- **FR-007:** The three stray literal `---` lines (≈ lines 458, 707, 721) MUST be deleted; they render as floating em-dashes between subsections.
+- **FR-008:** `\nocite{*}` (≈ line 1208) MUST be removed so the bibliography lists only works actually cited in text. Rationale: `\nocite{*}` pads the reference list with ~20 uncited entries.
+- **FR-009:** The one-line Acknowledgment ("This research paper used AI for assistance in generating content.") SHOULD be expanded to a complete generative-AI-use disclosure (tools named; authors take responsibility; review/verification stated) and the VTTI collaboration acknowledged.
+
+### 1.6 Submission Metadata (Should-have, non-rendering)
+- **FR-010:** Record the arXiv classification as a comment in the `.tex` preamble and in this spec: **primary `cs.CY`** (Computers & Society), **cross-list `stat.AP`** (Statistics – Applications), **optional cross-list `eess.SY`** (Systems & Control). `cs.SE` is NOT recommended as primary. Rationale: this is submission-form metadata, not body content; the comment is a convenience record.
+
+### 1.7 Out of Scope (explicitly NOT changed)
+- The time-averaged `\overline{SI}^{MCDM}_i` vs per-(i,t) MCDM nuance in the blend equation (subtle, not a contradiction with results) — leave as-is.
+- Any change to numerical results, figures, model formulas, or narrative conclusions.
+- arXiv directory flattening — not needed; this report's includes are already path-clean (single folder + `.bbl`).
+
+---
+
+## 2. Non-Functional Requirements
+
+### 2.1 Build Integrity
+- **NFR-001:** After all edits, `latexmk -pdf conference_101719.tex` MUST exit 0 with **zero undefined references** and **zero undefined citations**.
+- **NFR-002:** Overfull/underfull box count MUST NOT increase beyond the current baseline (1 overfull).
+
+### 2.2 Reversibility / Traceability
+- **NFR-003:** All edits MUST be confined to `conference_101719.tex` (no figure, bib, or code changes), each mapping to exactly one FR, so the diff is reviewable line-by-line.
+
+### 2.3 Fidelity
+- **NFR-004:** No edit may change a reported numeric result, equation, or experimental conclusion; edits only correct inconsistencies *toward the deployed-code ground truth* or remove non-content artifacts.
+
+---
+
+## 3. System Constraints
+- **C-1:** IEEEtran `conference` class; biblatex/biber backend; compiled with TeX Live 2025 `latexmk`.
+- **C-2:** Single-file source; bibliography `reference.bib`; figures are local `.png` + `system-architecture.tex` `\input`.
+- **C-3:** Ground-truth authority is the deployed backend, not prior drafts.
+
+---
+
+## 4. Acceptance Criteria
+- **AC-1 (FR-001):** `grep "lambda^\star" conference_101719.tex` shows `100000` everywhere; no remaining `\lambda^\star = 10000`.
+- **AC-2 (FR-002):** Appendix "Final Blend" affirms α-blend shipped at default 0.7 and references the §IV blended equation; the string "No blending parameter" is absent.
+- **AC-3 (FR-003/004):** Each perturbation/deviation appendix sentence references the matching `-birch` and `-broad` labels exactly once each; no label referenced twice in the same sentence.
+- **AC-4 (FR-005):** `grep "Team Member Contribution" conference_101719.tex` returns nothing; `\label{appendix:contributions}` is gone; document still compiles.
+- **AC-5 (FR-006):** No `\pm 50\%` claim remains in Results §IX.
+- **AC-6 (FR-007):** No standalone `---` lines remain in the body.
+- **AC-7 (FR-008):** `\nocite{*}` is absent; bibliography length decreases; still no undefined citations.
+- **AC-8 (FR-009):** Acknowledgment is a multi-sentence AI-use + VTTI disclosure.
+- **AC-9 (FR-010):** arXiv-class comment present in preamble.
+- **AC-10 (NFR-001):** Clean `latexmk` build, 0 undefined refs/cites, PDF produced.
+
+---
+
+## 5. Priority Summary
+| Priority | Requirements |
+|----------|-------------|
+| Must-have | FR-001 … FR-006, NFR-001, NFR-003, NFR-004 |
+| Should-have | FR-007 … FR-010, NFR-002 |
+| Nice-to-have | — |

--- a/files/conference_101719.tex
+++ b/files/conference_101719.tex
@@ -1,3 +1,8 @@
+%% arXiv submission classification (metadata; set on the arXiv submission form):
+%%   Primary:    cs.CY  (Computers and Society)
+%%   Cross-list: stat.AP (Statistics - Applications)
+%%   Optional:   eess.SY (Systems and Control)
+%% Note: cs.SE (Software Engineering) is NOT recommended as primary.
 \documentclass[conference]{IEEEtran}
 \usepackage{textalpha}
 
@@ -419,7 +424,7 @@ over a log-spaced grid
 
 After extending this grid, the optimal value was found to be
 \[
-\lambda^\star = 10000.
+\lambda^\star = 100000.
 \]
 In production we fix $\lambda = \lambda^\star$ and use the corresponding
 $\hat r^{\text{EB}}_{i,t}(\lambda^\star)$ as the stabilized historical component
@@ -454,8 +459,6 @@ H_{i,t} &= \min\!\left(1,\;k_5\frac{V^{\text{veh}}_{i,t}}{\mathrm{capacity}_i}\r
 \mathrm{SI}^{\text{RT}}_{i,t} \;=\; 100 \times
 \frac{\mathrm{COMB}_{i,t}-\min}{\max-\min}.
 \end{equation}
-
----
 
 \subsection{Decision Matrix and Temporal Aggregation}
 
@@ -702,13 +705,12 @@ with $W_E + W_C + W_S = 1$. In the implementation, we set the
 \emph{Safety Score} equal to this hybrid index (no inversion), so higher values
 correspond directly to higher estimated risk for that intersection and
 15-minute time bin, consistent with hybrid MCDM formulations in transportation
-safety~\cite{Amraji2025CombinedSafetyIndex}. 
-
----
+safety~\cite{Amraji2025CombinedSafetyIndex}.
 
 \subsection{Blended Final Index}
 To harmonize real-time safety with long-term prioritization, we define
 \begin{equation}
+\label{eq:blended-final}
 \mathrm{SI}^{\text{Final}}_{i,t} = \alpha \cdot \mathrm{SI}^{\text{RT}}_{i,t} +
 (1-\alpha)\cdot \overline{\mathrm{SI}}^{\text{MCDM}}_i,
 \end{equation}
@@ -717,8 +719,6 @@ where $\alpha$ tunes the emphasis (e.g., $\alpha=0.7$ for driver-facing dashboar
 \subsubsection{Rationale for a Blended Safety Index}
 
 We blend the real-time MCDM with the historically informed RT–SI index because each captures complementary aspects of risk: RT–SI reflects immediate operational turbulence, while the MCDM index integrates long-term crash patterns and structural exposure. The weighted combination reduces volatility, prevents overreaction to noisy inputs, and produces a more stable and interpretable score for deployment~\cite{montella2020systemic, Amraji2025CombinedSafetyIndex}. Full justification is provided in the Appendix.
-
----
 
 \section{System Design}
 \label{sec:systemdesign}
@@ -1045,10 +1045,10 @@ situational awareness for operators and planners~\cite{Amraji2025CombinedSafetyI
 
 \subsection{Sensitivity Analysis}
 
-Parameter perturbation experiments (\(\pm 25\%\) and \(\pm 50\%\)) showed that RT--SI is
+Parameter perturbation experiments (\(\pm 25\%\)) showed that RT--SI is
 robust to moderate changes in uplift-factor weights, with typical deviations less than one
-point on the 0--100 scale. The index becomes more volatile under extreme parameter
-changes or under very low-volume conditions. These results indicate that the chosen
+point on the 0--100 scale. The index becomes more volatile under very low-volume
+conditions. These results indicate that the chosen
 features capture stable operational signals but also highlight regimes where additional
 context (e.g., conflict topology or multimodal interactions) would improve stability
 \cite{gettman2003ssam, wang2021highres}.
@@ -1203,9 +1203,13 @@ Limitations and Future Work section outlines the evolution from flat numerical s
 toward a relational, agentic, and predictive safety-intelligence architecture.
 
 \section*{Acknowledgment}
-This research paper used AI for assistance in generating content.
+The VTTSI system was developed in collaboration with the Virginia Tech
+Transportation Institute (VTTI). Generative AI tools, including OpenAI ChatGPT
+(GPT-4o) and Anthropic Claude, were used to assist in preparing portions of this
+work, including manuscript text, \LaTeX{} formatting, and code snippets. All
+AI-generated content was reviewed, verified, and edited by the authors, who take
+full responsibility for the accuracy and integrity of the submitted manuscript.
 
-\nocite{*}
 \printbibliography
 
 \vspace{0.5em}
@@ -1213,39 +1217,6 @@ This research paper used AI for assistance in generating content.
 \clearpage
 \appendices
 
-\section{Team Member Contribution Report}
-\label{appendix:contributions}
-
-This section summarizes each team member’s contributions to the final project, consistent with the task assignments outlined in Appendix~A. Each member played a distinct role in the development of the Safety Index (SI) system, contributing across areas such as data engineering, interface design, algorithmic modeling, and exploratory research.
-
-\subsection{Cheng-Shun}
-
-Cheng-Shun has led the core software engineering, system integration, and data processing efforts for the project. He developed the complete backend API using \texttt{FastAPI} and implemented the interactive frontend visualization interface using \texttt{Streamlit}. He also designed and deployed the full data-delivery pipeline connecting raw data sources and database, the backend services, and the frontend dashboards and pages except analytics and validation page.
-
-A major component of his contribution is the end-to-end integration of heterogeneous data streams, BSM/PSM telemetry, vehicle and VRU counts, speed distributions, incident detections, and database resident historical crash records—into a unified visualization platform. Cheng-Shun implemented dynamic visualization modules that display temporal trends, statistical summaries, normalized variable comparisons, and permutation-style overlays of safety-relevant signals to support rapid diagnostic analysis of intersections. That means most of the system architecture show in this report is build by his own.
-
-He implemented the full mathematical formulation of the Safety Index proposed in methodology, including the Empirical Bayes baseline, uplift factors, and the CRITIC-weighted multi-criteria decision-making (MCDM) framework (SAW, EDAS, CODAS) used to compute real-time risk scores. He further integrated these algorithms directly into the backend, enabling automated computation of RT--SI, MCDM, and blended indices for every 15-minute interval.
-
-In addition, Cheng-Shun conducted the complete case-study evaluation and validation and sensitivity analysis for the intersections, generating the full suite of trend plots, correlation matrices, normalized comparisons, and interpretive assessments. This analysis demonstrated that the Safety Index behaves coherently with respect to exposure patterns, near-miss activity, speed variance, and operational anomalies.
-
-\subsection{Jason}
-
-Jason contributed to the architectural design, analytical foundations, and conceptual evolution of the Safety Index framework. He extended the system architecture by designing and implementing the \emph{plug-in data ingestion framework}, enabling new data sources—such as traffic camera imagery and weather feeds—to be incorporated seamlessly into the real-time processing pipeline. This flexible ingestion layer forms the basis for future multi-source expansion as described in the Limitations and Future Work.
-
-Jason performed exploratory data mining on the VTTI data portal and established the methodology used to preprocess and structure the historical crash and real-time telemetry datasets. He refined the initial mathematical structure of the Safety Index, identifying which real-time and historical features were most meaningful based on evidence from prior literature. He also attempted an early implementation of the MCDM and CRITIC algorithms in the backend; while this implementation was later superseded, it informed the final structure of the hybrid scoring pipeline.
-
-In addition to analytic contributions, Jason authored the project's \textbf{research questions}, the \textbf{limitations analysis}, and the \textbf{future-work direction}, including the conceptual design of the Agentic Traffic Safety Knowledge Graph (TS--KG). This agentic KG vision provides a roadmap for extending the system beyond flat numerical features toward relational reasoning, multimodal context, and explainable safety intelligence.
-
-Overall, Jason’s contributions shaped both the theoretical underpinnings and the forward-looking architecture of the VTTSI system, helping define the long-term trajectory of the project.
-
-\subsection{Victory}
-
-Victory has contributed through literature synthesis and conceptual support. She has provided insight into the research framing of the project and is investigating potential \textbf{external variables}—such as environmental, temporal, or behavioral factors—that could enhance the predictive capability of the Safety Index model. Her upcoming tasks involve curating these additional factors and testing their correlation strength against the core VTTI datasets.
-
-\subsection{Contribution Wrap}
-Together, the team has established a solid foundation for the project, with all core system components under active development. Backend services and data pipelines are operational, the analytical framework is being refined, and research integration continues to guide the model’s evolution toward a fully functional and interpretable Safety Index system.
-
-\clearpage
 \section{Backend Service Descriptions}
 \label{appendix:backend-services}
 
@@ -1447,8 +1418,17 @@ W_S \,\mathrm{SAW}_{i,t}.
 \]
 
 \subsubsection{Final Blend}
-The current implementation exposes the real-time and MCDM indices separately.  
-No blending parameter $\alpha$ is applied in the released code. The final index range from 0 to 100 which indicate very safe to very dangerous.
+The released backend computes both the real-time (RT--SI) and MCDM indices and
+combines them into the blended Final Safety Index of
+Eq.~\eqref{eq:blended-final},
+$\mathrm{SI}^{\text{Final}}_{i,t} = \alpha\,\mathrm{SI}^{\text{RT}}_{i,t} +
+(1-\alpha)\,\overline{\mathrm{SI}}^{\text{MCDM}}_i$.
+The blend coefficient defaults to $\alpha = 0.7$ and is exposed both as a
+request parameter on the safety-index API endpoint and as an interactive
+slider in the Streamlit frontend, allowing operators to shift continuously
+between the historical-risk pole (RT--SI, $\alpha\!\to\!1$) and the
+operational-anomaly pole (MCDM, $\alpha\!\to\!0$). The final index ranges from
+0 (very safe) to 100 (very dangerous).
 
 \section{Additional Validation Figures}
 \label{appendix:validation}
@@ -1556,9 +1536,9 @@ Additional information of this sections, including other intersections' results 
 
 \subsection{Other intersections' results}
 
-Figure~\ref{fig:perturbed-rt-si-comparison-birch} and figure~\ref{fig:all-variable-normalized-broad} are perturbation results of other intersections.
+Figure~\ref{fig:perturbed-rt-si-comparison-birch} and figure~\ref{fig:perturbed-rt-si-comparison-broad} are perturbation results of other intersections.
 
-Figure~\ref{fig:rt-si-changes-distribution-broad} and figure~\ref{fig:rt-si-changes-distribution-broad} are distribution of deviations of perturbations in other intersections.
+Figure~\ref{fig:rt-si-changes-distribution-birch} and figure~\ref{fig:rt-si-changes-distribution-broad} are distribution of deviations of perturbations in other intersections.
 
 Figure~\ref{fig:weight-importance-rt-si-birch} and figure~\ref{fig:weight-importance-rt-si-broad} shows importances of different weights in other intersections.
 


### PR DESCRIPTION
## Summary

Makes the VTTSI final report (`files/conference_101719.tex`) submission-ready for arXiv by removing factual contradictions, a course-only artifact, and cosmetic defects — **without altering any methodology, results, or conclusions**. Both contradictions were resolved against the **deployed backend** (code is the source of truth where the paper and code disagreed).

Adds `files/arxiv-remediation-spec.md` documenting the spec (10 FR / 4 NFR + acceptance criteria).

## Ground-truth resolutions
| Item | Paper said | Deployed code | Fix |
|------|-----------|---------------|-----|
| EB λ* | §IV `10000` vs Appendix `100000` | `rt_si_service.py:41 LAMBDA=100000.0` | §IV → `100000` |
| α blend | §IV/Validation: α=0.7 vs Appendix "no α applied" | `intersection.py:315` blends, default `alpha=0.7` | Appendix rewritten to match |

## Changes
- **λ\*** methodology `10000` → `100000`
- **Appendix "Final Blend"** rewritten: α-blend ships (default 0.7, API + slider), references the methodology equation; removed the incorrect "no α applied" line
- Fixed duplicated/incorrect appendix figure cross-references (birch/broad)
- Removed **Team Member Contribution Report** appendix (grading artifact, progress-report tense)
- Dropped unsupported "±50%" sensitivity claim (only ±25% was run)
- Removed stray `---` artifacts; dropped `\nocite{*}`; expanded AI-use + VTTI acknowledgment
- Recorded arXiv classification as a preamble comment (primary `cs.CY`, cross-list `stat.AP`, optional `eess.SY`)

## Verification
- `latexmk -pdf conference_101719.tex` exits 0, **0 undefined references/citations**, overfull boxes unchanged (1), PDF regenerated (21 → 19 pp after appendix removal)

## Out of scope
- arXiv category selection is metadata for the submission form (recorded as a comment, not body content)
- Per-(i,t) vs time-averaged MCDM notation nuance left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)