### PR TITLE
Remove non-contributing author from VTTSI report

### DIFF
--- a/files/conference_101719.tex
+++ b/files/conference_101719.tex
@@ -57,13 +57,7 @@ djjay@vt.edu \\
 \IEEEauthorblockN{Cheng-Shun Chuang}
 \IEEEauthorblockA{ \textit{Computer Science} \\
 Virginia Tech \\ Alexandria, VA, USA \\
-cchengshun@vt.edu}
-\and 
-\IEEEauthorblockN{Victory Uhunmwangho}
-\IEEEauthorblockA{\textit{Computer Science} \\
-\textit{Virginia Tech}\\
-Blacksburg, VA, USA \\
-victoryu@vt.edu}}
+cchengshun@vt.edu}}
 
 \maketitle
 


### PR DESCRIPTION
Removes **Victory Uhunmwangho** from the author block of `files/conference_101719.tex` — she did not contribute to the paper. Her contribution-report subsection was already removed in the prior arXiv-remediation pass (#28), so this only updates the author list, now **Cusati and Chuang**.

Verified: clean `latexmk` build, 0 undefined references/citations, 19 pp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)