### PR TITLE
Preprint polish: drop LEADER tag and class-report framing

### DIFF
--- a/files/conference_101719.tex
+++ b/files/conference_101719.tex
@@ -51,8 +51,7 @@
 \author{\IEEEauthorblockN{Jason Cusati}
 \IEEEauthorblockA{\textit{Computer Science} \\
 Virginia Tech \\ Blacksburg, VA, USA \\
-djjay@vt.edu \\
-(LEADER)}
+djjay@vt.edu}
 \and
 \IEEEauthorblockN{Cheng-Shun Chuang}
 \IEEEauthorblockA{ \textit{Computer Science} \\
@@ -130,10 +129,9 @@ ranking across intersections. Together, these components produce a 0--100 real-t
 Safety Index updated every 15 minutes and presented through a cloud-native
 architecture.
 
-Although the project did not begin with formal research questions, the process of
-designing, validating, and analyzing VTTSI naturally revealed several important lines
-of inquiry. These questions help contextualize the contributions of the system and
-clarify the safety-related insights made possible by the framework.
+The design, validation, and analysis of VTTSI are organized around four research
+questions that frame the contributions of the system and the safety-related insights
+the framework enables.
 
 \subsection*{Research Questions}
 


### PR DESCRIPTION
Two small preprint-readiness cleanups to `files/conference_101719.tex`:

1. **Remove the `(LEADER)` tag** from the author block — a course-roster marker, not a preprint convention.
2. **Reframe the intro RQ lead-in** — presents RQ1–RQ4 as the paper's research questions instead of questions that "naturally revealed" themselves during the project, removing a class-report tell. The RQ structure (and the "Answers to Research Questions" section in Results) is unchanged.

Verified: clean `latexmk` build, 0 undefined references/citations, 19 pp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)